### PR TITLE
Fix spacing hint text

### DIFF
--- a/asset/rules/spacing.js
+++ b/asset/rules/spacing.js
@@ -1,7 +1,7 @@
 ESLintConfigGenApp.rules.spacing = [
   {
     key: "rules.indent",
-    hint: "Allow JSX",
+    hint: "My indentation preferences",
     variants: [
       {
         hint: "2 Spaces",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Spacing settings step has "Allow JSX" title. I've changed this hint with a proper one.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
Tested in Chrome 63
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- All test cases should be tested -->

## Tested on:
<!--- All of these should be checked(put x)  -->
- [x] Desktop Chrome.
- [x] Desktop Safari.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated (any) documentation accordingly.
