### PR TITLE
Remove unneeded IE8 code (the links didn't work anyway)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,12 +7,6 @@
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="{{ '/assets/js/respond.js' | relative_url }}"></script>
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <!--[if lt IE 8]>
-    <link rel="stylesheet" href="{{ '/assets/css/ie.css' | relative_url }}">
-    <![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
   </head>


### PR DESCRIPTION
Remove JS link to `html5shiv.googlecode.com/svn/trunk/html5.js` as that is no longer active
Remove CSS link `/assets/css/ie.css`as file isn't there an no need to support IE7 (!)